### PR TITLE
Add GitHub Action for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Publish
+      run: dotnet publish Pinger -v d /p:PublishProfile=./Pinger/Properties/PublishProfiles/FolderProfile.pubxml
+
+    - name: Get version
+      id: get_version
+      run: echo "##[set-output name=VERSION;]$(./Pinger/bin/Release/net9.0/publish/win-x64/Pinger.exe -v | grep -oP '(?<=Version: ).*')"
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.get_version.outputs.VERSION }}
+        release_name: Release ${{ steps.get_version.outputs.VERSION }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./Pinger/bin/Release/net9.0/publish/win-x64/Pinger.exe
+        asset_name: Pinger.exe
+        asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'master'
 
 jobs:
   build:
@@ -14,7 +19,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
       with:
-        ref: master
+        ref: ${{ github.event.inputs.branch || 'master' }}
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Create Release
 
 on:
-  push:
+  pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        ref: master
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         tag_name: v${{ steps.get_version.outputs.VERSION }}
         release_name: Release ${{ steps.get_version.outputs.VERSION }}
-        draft: false
+        draft: ${{ github.event.inputs.branch != 'master' }}
         prerelease: false
 
     - name: Upload Release Asset


### PR DESCRIPTION
Add GitHub Actions workflow for release creation.

* Create `.github/workflows/release.yml` file.
* Define workflow to trigger on push events to the `main` branch and manual dispatch.
* Add steps to checkout repository, setup .NET, restore dependencies, build, and publish the project.
* Add step to get version from `Pinger.exe`.
* Add steps to create a new release and upload the `Pinger.exe` artifact.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Infarh/Pinger/pull/1?shareId=42533ddc-c73a-494c-a46d-e05f06f14ff8).